### PR TITLE
Color overlay

### DIFF
--- a/xact/xk/xact/api/CraftingHandler.java
+++ b/xact/xk/xact/api/CraftingHandler.java
@@ -289,6 +289,32 @@ public abstract class CraftingHandler {
 		return retValue.equals("") ? "none." : retValue;
 	}
 
+	public boolean[] getMissingIngredientsArray(CraftRecipe recipe) {
+		boolean[] missingArray = new boolean[9];
+		if( recipe == null ) {
+			return missingArray;
+		}
+
+		ItemStack[] ingredients = recipe.getIngredients();
+		ItemStack[] missingIngredients = getMissingIngredients( recipe ).clone();
+
+		for( ItemStack currentMissed : missingIngredients ) {
+			if( currentMissed == null )
+				continue;
+
+			int remaining = currentMissed.stackSize;
+			for( int i = 0; remaining > 0 && i < ingredients.length; i++ ) {
+			    if( ingredients[i] != null && ingredients[i].isItemEqual( currentMissed ) ) {
+					remaining--;
+					missingArray[i] = true;
+				}
+
+			}
+		}
+
+		return missingArray;
+	}
+
     protected ItemStack[] findAndGetRecipeIngredients(CraftRecipe recipe, boolean doRemove) {
         ItemStack[] ingredients = recipe.getIngredients();
         ItemStack[] contents = new ItemStack[recipe.size]; // the return value.

--- a/xact/xk/xact/gui/GuiPad.java
+++ b/xact/xk/xact/gui/GuiPad.java
@@ -34,20 +34,19 @@ public class GuiPad extends GuiContainer implements InteractiveCraftingGui {
 		// draw the button
 		if( craftPad.buttonID != -1 )
 			this.drawTexturedModalRect(cornerX+97, cornerY+63, 	176, craftPad.buttonID*14, 	14, 14);
-
-		// draw the text box?
-
-		// todo: paint a red overlay if can't craft the items, or something like that.
 	}
 
 	@Override
 	public void drawGuiContainerForegroundLayer(int x, int y) {
-		// the title
+		// the titles
 		int xPos = 11 + (112 - fontRenderer.getStringWidth("Craft Pad")) / 2;
 		this.fontRenderer.drawString("Craft Pad", xPos, 8, 4210752);
 
 		xPos = 126 + (40 - fontRenderer.getStringWidth("Chip")) /2;
 		this.fontRenderer.drawString("Chip", xPos, 23, 4210752);
+
+		// Paint the grid's overlays.
+		paintSlotOverlays();
 	}
 
 	@Override
@@ -109,6 +108,32 @@ public class GuiPad extends GuiContainer implements InteractiveCraftingGui {
 				FMLCommonHandler.instance().raiseException(ioe, "GuiPad: custom packet", true);
 			}
 		}
+	}
+
+
+	private void paintSlotOverlays() {
+
+		// Items overlay: (alpha 50%)
+			// normal = gray
+			// missing = red
+
+		int gray = GuiUtils.COLOR_GRAY | 128;
+		int red = GuiUtils.COLOR_RED | 128;
+
+		boolean[] missingIngredients = craftPad.getHandler().getMissingIngredientsArray( craftPad.getRecipe(0) );
+
+		for( int index = 1; index <= 9; index++ ) {
+			Slot slot = (Slot) this.inventorySlots.inventorySlots.get( index );
+			if( slot == null )
+				continue;
+
+			int color = missingIngredients[index-1] ? red : gray;
+
+			GuiUtils.paintSlotOverlay(slot, 16, color);
+		}
+
+		// todo: paint the overlay on the output slot.
+
 	}
 
 }

--- a/xact/xk/xact/gui/GuiPad.java
+++ b/xact/xk/xact/gui/GuiPad.java
@@ -117,8 +117,10 @@ public class GuiPad extends GuiContainer implements InteractiveCraftingGui {
 			// normal = gray
 			// missing = red
 
-		int gray = GuiUtils.COLOR_GRAY | 128;
-		int red = GuiUtils.COLOR_RED | 128;
+		int transparency = 128 << 24;
+
+		int gray =  transparency | GuiUtils.COLOR_GRAY;
+		int red = transparency | GuiUtils.COLOR_RED;
 
 		boolean[] missingIngredients = craftPad.getHandler().getMissingIngredientsArray( craftPad.getRecipe(0) );
 

--- a/xact/xk/xact/gui/GuiUtils.java
+++ b/xact/xk/xact/gui/GuiUtils.java
@@ -9,10 +9,10 @@ public class GuiUtils {
 
 	private static int grayTone = 139;
 
-	public static final int COLOR_RED = 255 << 8;
-	public static final int COLOR_GREEN = 255 << 16;
-	public static final int COLOR_BLUE = 255 << 24;
-	public static final int COLOR_GRAY = (grayTone << 24) | (grayTone << 16) | (grayTone << 8);
+	public static final int COLOR_RED = 255 << 16;
+	public static final int COLOR_GREEN = 255 << 8;
+	public static final int COLOR_BLUE = 255;
+	public static final int COLOR_GRAY = (grayTone << 16) | (grayTone << 8) | grayTone << 8;
 
 	public static void paintSlotOverlay(Slot slot, int size, int color) {
 		if( slot == null )

--- a/xact/xk/xact/gui/GuiUtils.java
+++ b/xact/xk/xact/gui/GuiUtils.java
@@ -9,10 +9,10 @@ public class GuiUtils {
 
 	private static int grayTone = 139;
 
-	public static final int COLOR_RED = 255 << 16;
-	public static final int COLOR_GREEN = 255 << 8;
-	public static final int COLOR_BLUE = 255;
-	public static final int COLOR_GRAY = (grayTone << 16) | (grayTone << 8) | grayTone << 8;
+	public static final int COLOR_RED = 180 << 16;
+	public static final int COLOR_GREEN = 180 << 8;
+	public static final int COLOR_BLUE = 220;
+	public static final int COLOR_GRAY = (grayTone << 16) | (grayTone << 8) | grayTone;
 
 	public static void paintSlotOverlay(Slot slot, int size, int color) {
 		if( slot == null )

--- a/xact/xk/xact/gui/GuiUtils.java
+++ b/xact/xk/xact/gui/GuiUtils.java
@@ -1,0 +1,32 @@
+package xk.xact.gui;
+
+
+import net.minecraft.src.Gui;
+import net.minecraft.src.Slot;
+import org.lwjgl.opengl.GL11;
+
+public class GuiUtils {
+
+	private static int grayTone = 139;
+
+	public static final int COLOR_RED = 255 << 8;
+	public static final int COLOR_GREEN = 255 << 16;
+	public static final int COLOR_BLUE = 255 << 24;
+	public static final int COLOR_GRAY = (grayTone << 24) | (grayTone << 16) | (grayTone << 8);
+
+	public static void paintSlotOverlay(Slot slot, int size, int color) {
+		if( slot == null )
+			return;
+
+		int off = ( size - 16 ) / 2;
+		int minX = slot.xDisplayPosition - off;
+		int minY = slot.yDisplayPosition - off;
+
+		GL11.glDisable(GL11.GL_LIGHTING);
+		GL11.glDisable(GL11.GL_DEPTH_TEST);
+		Gui.drawRect(minX, minY, minX + size, minY + size, color);
+		GL11.glEnable(GL11.GL_LIGHTING);
+		GL11.glEnable(GL11.GL_DEPTH_TEST);
+	}
+
+}


### PR DESCRIPTION
The Craft Pad grid now shows "ghost" items: that mean, it paints a gray overlay over the slots, and a red one over the missing ingredients.
